### PR TITLE
Containers周りの設計修正

### DIFF
--- a/src/main/java/raven/ravenstorages/RavenStorages.java
+++ b/src/main/java/raven/ravenstorages/RavenStorages.java
@@ -1,11 +1,7 @@
 package raven.ravenstorages;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.gui.ScreenManager;
-import net.minecraft.inventory.container.ContainerType;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.Capability;
@@ -19,21 +15,19 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import raven.ravenstorages.blocks.RavenBlocks;
-import raven.ravenstorages.client.screen.DebugAnchorScreen;
-import raven.ravenstorages.containers.DebugContainerScreen;
-import raven.ravenstorages.containers.RavenContainers;
-import raven.ravenstorages.containers.RavenDefContainers;
-import raven.ravenstorages.tiles.RavenTiles;
 import raven.ravenstorages.capability.CapabilityDebugHandler;
 import raven.ravenstorages.capability.CapabilityDebugHandler.DebugHandler;
 import raven.ravenstorages.capability.SingleCapabilityProvider;
+import raven.ravenstorages.client.screen.DebugAnchorScreen;
+import raven.ravenstorages.containers.RavenContainers;
+import raven.ravenstorages.containers.RavenDefContainers;
 import raven.ravenstorages.item.RavenItems;
+import raven.ravenstorages.tiles.RavenTiles;
 
 import javax.annotation.Nonnull;
 
 import static raven.ravenstorages.RavenStorages.MOD_ID;
-import static raven.ravenstorages.containers.RavenContainers.DEBUG_CONTAINER;
-import static raven.ravenstorages.containers.RavenDefContainers.*;
+import static raven.ravenstorages.containers.RavenDefContainers.DEBUG_ANCHOR_CONTAINER;
 
 @Mod(MOD_ID)
 public final class RavenStorages {
@@ -45,8 +39,7 @@ public final class RavenStorages {
         RavenBlocks.register(modEventBus);
         RavenTiles.register(modEventBus);
         RavenItems.register(modEventBus);
-
-        modEventBus.addGenericListener(ContainerType.class, RavenContainers::register);
+        RavenContainers.register(modEventBus);
 
         //Deferred
         RavenDefContainers.onRegistration(modEventBus);
@@ -63,8 +56,6 @@ public final class RavenStorages {
     }
 
     private void clientSetup(@Nonnull FMLClientSetupEvent event) {
-        ScreenManager.registerFactory(DEBUG_CONTAINER, DebugContainerScreen::new);
-
         ScreenManager.registerFactory(DEBUG_ANCHOR_CONTAINER.get(), DebugAnchorScreen::new);
     }
 

--- a/src/main/java/raven/ravenstorages/blocks/DebugContainerBlock.java
+++ b/src/main/java/raven/ravenstorages/blocks/DebugContainerBlock.java
@@ -4,23 +4,18 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.entity.player.ServerPlayerEntity;
-import net.minecraft.inventory.container.Container;
-import net.minecraft.inventory.container.INamedContainerProvider;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
-import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.network.NetworkHooks;
-import raven.ravenstorages.containers.DebugContainer;
+import raven.ravenstorages.containers.RavenContainers;
 
 import javax.annotation.Nonnull;
 
-final class DebugContainerBlock extends Block implements INamedContainerProvider {
+final class DebugContainerBlock extends Block {
     DebugContainerBlock() {
         super(Properties.create(Material.IRON));
     }
@@ -29,23 +24,12 @@ final class DebugContainerBlock extends Block implements INamedContainerProvider
     @Override
     @Nonnull
     public ActionResultType onBlockActivated(@Nonnull BlockState state, @Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull PlayerEntity player, @Nonnull Hand handIn, @Nonnull BlockRayTraceResult hit) {
-        if(worldIn.isRemote()) return ActionResultType.PASS;
+        if(worldIn.isRemote()) return ActionResultType.SUCCESS;
         if(!(player instanceof ServerPlayerEntity)) return ActionResultType.FAIL;
 
         ServerPlayerEntity serverPlayer = (ServerPlayerEntity)player;
-        NetworkHooks.openGui(serverPlayer, this);
+        NetworkHooks.openGui(serverPlayer, RavenContainers.DEBUG_CONTAINER_PROVIDER);
 
         return ActionResultType.SUCCESS;
-    }
-
-    @Nonnull
-    @Override
-    public Container createMenu(int windowID, @Nonnull PlayerInventory playerInventory, @Nonnull PlayerEntity playerEntity) {
-        return DebugContainer.createServerSide(windowID, playerInventory);
-    }
-
-    @Override
-    public ITextComponent getDisplayName() {
-        return new StringTextComponent("DebugContainer");
     }
 }

--- a/src/main/java/raven/ravenstorages/containers/DebugContainer.java
+++ b/src/main/java/raven/ravenstorages/containers/DebugContainer.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import static java.util.Collections.unmodifiableList;
 
-public final class DebugContainer extends SlotPositionLessContainer {
+final class DebugContainer extends SlotPositionLessContainer {
     public static DebugContainer createServerSide(int windowId, PlayerInventory playerInventory) {
         return new DebugContainer(windowId, playerInventory);
     }
@@ -43,7 +43,7 @@ public final class DebugContainer extends SlotPositionLessContainer {
 
 
     private DebugContainer(int windowId, PlayerInventory playerInventory) {
-        super(RavenContainers.DEBUG_CONTAINER, windowId);
+        super(RavenContainers.DEBUG_CONTAINER.get(), windowId);
         mainItemHandler = new ItemStackHandler(MAIN_SLOT_COUNT);
         playerInventoryItemHandler = new PlayerMainInvWrapper(playerInventory);
 

--- a/src/main/java/raven/ravenstorages/containers/DebugContainerProvider.java
+++ b/src/main/java/raven/ravenstorages/containers/DebugContainerProvider.java
@@ -1,0 +1,30 @@
+package raven.ravenstorages.containers;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.container.Container;
+import net.minecraft.inventory.container.INamedContainerProvider;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+
+import javax.annotation.Nonnull;
+
+final class DebugContainerProvider implements INamedContainerProvider {
+    private final ITextComponent displayName;
+
+    DebugContainerProvider() {
+        this.displayName = new StringTextComponent("Debug Container");
+    }
+
+    @Override
+    @Nonnull
+    public ITextComponent getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    @Nonnull
+    public Container createMenu(int windowID, @Nonnull PlayerInventory playerInventory, @Nonnull PlayerEntity playerEntity) {
+        return DebugContainer.createServerSide(windowID, playerInventory);
+    }
+}

--- a/src/main/java/raven/ravenstorages/containers/DebugContainerScreen.java
+++ b/src/main/java/raven/ravenstorages/containers/DebugContainerScreen.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 import static raven.ravenstorages.RavenStorages.MOD_ID;
 
-public final class DebugContainerScreen extends SlotPositionHoldingContainerScreen<DebugContainer> {
+final class DebugContainerScreen extends SlotPositionHoldingContainerScreen<DebugContainer> {
     public DebugContainerScreen(DebugContainer screenContainer, PlayerInventory playerInventory, ITextComponent title) {
         super(screenContainer, playerInventory, title);
     }

--- a/src/main/java/raven/ravenstorages/containers/RavenContainers.java
+++ b/src/main/java/raven/ravenstorages/containers/RavenContainers.java
@@ -1,26 +1,42 @@
 package raven.ravenstorages.containers;
 
+import net.minecraft.client.gui.ScreenManager;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.ContainerType;
+import net.minecraft.inventory.container.INamedContainerProvider;
 import net.minecraftforge.common.extensions.IForgeContainerType;
-import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.network.IContainerFactory;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import javax.annotation.Nonnull;
+import java.util.function.Supplier;
 
 import static raven.ravenstorages.RavenStorages.MOD_ID;
 
 public final class RavenContainers {
     private RavenContainers() { throw new AssertionError(); }
 
-    public static final ContainerType<DebugContainer> DEBUG_CONTAINER = create(DebugContainer::createClientSide, "debug_container");
+    private static final DeferredRegister<ContainerType<?>> CONTAINERS = DeferredRegister.create(ForgeRegistries.CONTAINERS, MOD_ID);
 
-    public static void register(@Nonnull RegistryEvent.Register<ContainerType<?>> event) {
-        event.getRegistry().registerAll(DEBUG_CONTAINER);
+    public static final RegistryObject<ContainerType<DebugContainer>> DEBUG_CONTAINER = CONTAINERS.register("debug_container", create(DebugContainer::createClientSide));
+
+    public static final INamedContainerProvider DEBUG_CONTAINER_PROVIDER = new DebugContainerProvider();
+
+    public static void register(@Nonnull IEventBus modEventBus) {
+        CONTAINERS.register(modEventBus);
+        modEventBus.addListener(RavenContainers::registerScreen);
     }
-    private static <T extends Container> ContainerType<T> create(@Nonnull IContainerFactory<T> factory, @Nonnull String name) {
-        ContainerType<T> type = IForgeContainerType.create(factory);
-        type.setRegistryName(MOD_ID, name);
-        return type;
+
+    private static void registerScreen(@Nonnull FMLClientSetupEvent event) {
+        ScreenManager.registerFactory(DEBUG_CONTAINER.get(), DebugContainerScreen::new);
+    }
+
+    @Nonnull
+    private static <T extends Container> Supplier<ContainerType<T>> create(@Nonnull IContainerFactory<T> clientContainerFactory) {
+        return () -> IForgeContainerType.create(clientContainerFactory);
     }
 }


### PR DESCRIPTION
Container, ContainerScreen, ContaienrProviderを同じパッケージ下に定義
全てをpackage-privateとし、RavenContainersでのみpublicな参照を公開する方針に